### PR TITLE
B005_btn_inverse_border

### DIFF
--- a/sites/all/themes/cetaviano/sass/partials/patterns/_buttons.scss
+++ b/sites/all/themes/cetaviano/sass/partials/patterns/_buttons.scss
@@ -28,5 +28,5 @@ a.btn-secondary,
 
 .btn-secondary--inverse a,
 a.btn-secondary--inverse {
-    @include btn($orange, $white, $white, $orange);
+    @include btn($orange, $white, $white, $orange, $orange);
 }


### PR DESCRIPTION
Cometí un error y mande el boton btn-inverse con borde blanco en vez de naranja.